### PR TITLE
Weather API token fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,4 +65,6 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
       - name: Run tests
+        env:
+          WEATHER_API_TOKEN: ${{ secrets.WEATHER_API_TOKEN }}
         run: ./bin/rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,4 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
       - name: Run tests
-        env:
-          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
         run: ./bin/rspec
-

--- a/app/services/weather_fetcher.rb
+++ b/app/services/weather_fetcher.rb
@@ -17,7 +17,8 @@ class WeatherFetcher
     forecast = Rails.cache.fetch(cache_key, expires_in: 30.minutes, force: force) do
       cache_hit = false
       params = { alerts: "no", aqi: "no", days: "5", key: api_key, q: zip }
-      query = URI.encode_www_form(params)
+      sorted_params = params.sort_by { |k, _| k.to_s }
+      query = URI.encode_www_form(sorted_params)
 
       uri = URI("https://api.weatherapi.com/v1/forecast.json?#{query}")
 

--- a/app/services/weather_fetcher.rb
+++ b/app/services/weather_fetcher.rb
@@ -10,6 +10,8 @@ class WeatherFetcher
     cache_hit = true
 
     api_key = ENV["WEATHER_API_TOKEN"] || Rails.application.credentials.dig(:weather_api, :token)
+    puts "WEATHER_API_TOKEN size: #{ENV["WEATHER_API_TOKEN"].to_s.length}"
+    puts "CREDENTIAL TOKEN size: #{Rails.application.credentials.dig(:weather_api, :token)}"
     puts "API_KEY size: #{api_key.to_s.length}"
 
     forecast = Rails.cache.fetch(cache_key, expires_in: 30.minutes, force: force) do

--- a/app/services/weather_fetcher.rb
+++ b/app/services/weather_fetcher.rb
@@ -10,6 +10,7 @@ class WeatherFetcher
     cache_hit = true
 
     api_key = ENV["WEATHER_API_TOKEN"] || Rails.application.credentials.dig(:weather_api, :token)
+    puts "API_KEY size: #{api_key.to_s.length}"
 
     forecast = Rails.cache.fetch(cache_key, expires_in: 30.minutes, force: force) do
       cache_hit = false

--- a/app/services/weather_fetcher.rb
+++ b/app/services/weather_fetcher.rb
@@ -10,15 +10,11 @@ class WeatherFetcher
     cache_hit = true
 
     api_key = ENV["WEATHER_API_TOKEN"] || Rails.application.credentials.dig(:weather_api, :token)
-    puts "WEATHER_API_TOKEN size: #{ENV["WEATHER_API_TOKEN"].to_s.length}"
-    puts "CREDENTIAL TOKEN size: #{Rails.application.credentials.dig(:weather_api, :token)}"
-    puts "API_KEY size: #{api_key.to_s.length}"
 
     forecast = Rails.cache.fetch(cache_key, expires_in: 30.minutes, force: force) do
       cache_hit = false
       params = { alerts: "no", aqi: "no", days: "5", key: api_key, q: zip }
-      sorted_params = params.sort_by { |k, _| k.to_s }
-      query = URI.encode_www_form(sorted_params)
+      query = URI.encode_www_form(params)
 
       uri = URI("https://api.weatherapi.com/v1/forecast.json?#{query}")
 

--- a/spec/cassettes/weather/forecast_failure.yml
+++ b/spec/cassettes/weather/forecast_failure.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.weatherapi.com/v1/forecast.json?alerts=no&aqi=no&days=5&key=<WEATHER_API_KEY>&q=11111
+    uri: https://api.weatherapi.com/v1/forecast.json?alerts=no&aqi=no&days=5&key=<WEATHER_API_TOKEN>&q=11111
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/weather/forecast_success.yml
+++ b/spec/cassettes/weather/forecast_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.weatherapi.com/v1/forecast.json?alerts=no&aqi=no&days=5&key=<WEATHER_API_KEY>&q=29732
+    uri: https://api.weatherapi.com/v1/forecast.json?alerts=no&aqi=no&days=5&key=<WEATHER_API_TOKEN>&q=29732
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,7 +102,7 @@ VCR.configure do |config|
   config.hook_into :webmock
   config.configure_rspec_metadata!
 
-  config.filter_sensitive_data('<WEATHER_API_KEY>') do
-    Rails.application.credentials.dig(:weather_api, :token)
+  config.filter_sensitive_data('<WEATHER_API_TOKEN>') do
+    ENV['WEATHER_API_TOKEN'] || Rails.application.credentials.dig(:weather_api, :token)
   end
 end


### PR DESCRIPTION
default to use WEATHER_API_TOKEN for tests instead of relying on RAILS_MASTER_KEY